### PR TITLE
Reorder and redesign custom title tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: Continuous Integration
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   j4:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ inherit_gem:
   rubocop-jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 2.5
   SuggestExtensions: false
   Exclude:
     - vendor/**/*

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -103,7 +103,9 @@ module Jekyll
       end
 
       def determine_detailed_title
-        small_title = if page_pagination_title
+        small_title = if format_string(page["title_meta"])
+                        format_string(page["title_meta"])
+                      elsif page_pagination_title
                         add_page_number(:after, page_pagination_title)
                       elsif page_subtitle_title
                         add_page_number(:after, page_subtitle_title)

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -81,13 +81,7 @@ module Jekyll
 
       # Page title with site title or description appended
       def title
-        @title ||= if seo_custom_title?
-                     seo_custom_title
-                   else
-                     add_page_number(:before, generic_title)
-                   end
-
-        @title
+        @title ||= seo_custom_title? ? seo_custom_title : add_page_number(:before, generic_title)
       end
 
       def generic_title

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -63,6 +63,9 @@ module Jekyll
             else
               return "Blog – #{title}"
             end
+            title
+          else
+            nil
           end
         end
       end

--- a/lib/jekyll-seo-tag/drop.rb
+++ b/lib/jekyll-seo-tag/drop.rb
@@ -59,13 +59,10 @@ module Jekyll
           if page["pagination"]
             title = format_string(page["pagination"]["title"])
             if title == "Blog" || format_string(page["pagination"]["collection"]).nil?
-              return title
+              title
             else
-              return "Blog – #{title}"
+              "Blog – #{title}"
             end
-            title
-          else
-            nil
           end
         end
       end
@@ -73,7 +70,7 @@ module Jekyll
       def page_subtitle_title
         @page_subtitle_title ||= begin
           if page["title"] && page["subtitle"]
-            format_string(page["title"] + " – " + page["subtitle"])
+            format_string("#{page["title"]} – #{page["subtitle"]}")
           end
         end
       end
@@ -89,9 +86,9 @@ module Jekyll
 
       def generic_title
         if site_title && page_title != site_title
-          page_title + TITLE_SEPARATOR + site_title
+          "#{page_title}#{TITLE_SEPARATOR}#{site_title}"
         elsif site_description && site_title
-          site_title + TITLE_SEPARATOR + site_tagline_or_description
+          "#{site_title}#{TITLE_SEPARATOR}#{site_tagline_or_description}"
         else
           page_title || site_title
         end
@@ -116,7 +113,7 @@ module Jekyll
                         add_page_number(:after, site_tagline_or_description)
                       end
 
-        small_title + TITLE_SEPARATOR + site_title
+        "#{small_title}#{TITLE_SEPARATOR}#{site_title}"
       end
 
       def name
@@ -241,8 +238,8 @@ module Jekyll
 
       def add_page_number(placement, title)
         if page_number
-          return page_number + " " + title if placement == :before
-          return title + " " + page_number if placement == :after
+          return "#{page_number} #{title}" if placement == :before
+          return "#{title} #{page_number}" if placement == :after
         end
 
         title

--- a/lib/jekyll-seo-tag/json_ld_drop.rb
+++ b/lib/jekyll-seo-tag/json_ld_drop.rb
@@ -89,8 +89,8 @@ module Jekyll
 
       def to_json
         sort_order = [
-          'headline', 'name', 'url', 'mainEntityOfPage', 'dateModified', 'datePublished',
-          'author', 'publisher', 'description', 'sameAs', 'image', '@type', '@context'
+          "headline", "name", "url", "mainEntityOfPage", "dateModified", "datePublished",
+          "author", "publisher", "description", "sameAs", "image", "@type", "@context",
         ]
         hash = (sort_order & to_h.keys).map { |k| [k, to_h[k]] }.to_h
         hash.compact.to_json

--- a/lib/template.html
+++ b/lib/template.html
@@ -5,7 +5,7 @@
 
 <meta name="generator" content="Jekyll v{{ jekyll.version }}" />
 
-{% if seo_tag.site_title_prioritized? %}
+{% if seo_tag.seo_custom_title? %}
   {% if seo_tag.title? %}
     <meta property="og:title" content="{{ seo_tag.title }}" />
   {% endif %}

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -283,6 +283,15 @@ RSpec.describe Jekyll::SeoTag::Drop do
     end
 
     context "determine_detailed_title" do
+      context "with an overriding page title" do
+        let(:page_meta) do
+          { "title_meta" => "override", "pagination" => { "title" => "pagination title" } }
+        end
+
+        it "shows the override no matter what" do
+          expect(subject.determine_detailed_title).to eq("override | site title")
+        end
+      end
       context "with a page and site title" do
         it "builds the title" do
           expect(subject.determine_detailed_title).to eql("page title | site title")

--- a/spec/jekyll_seo_tag/drop_spec.rb
+++ b/spec/jekyll_seo_tag/drop_spec.rb
@@ -85,13 +85,41 @@ RSpec.describe Jekyll::SeoTag::Drop do
         end
       end
 
-      context "with pagination title" do
+      context "with pagination title and the title is not 'Blog', but collection does not exist" do
         let(:title)     { "Test Title" }
         let(:page_meta) { { "pagination" => { "title" => title } } }
         let(:page)      { make_page(page_meta) }
 
         it "will return the paginated title" do
           expect(subject.page_pagination_title).to eql(title)
+        end
+      end
+
+      context "with the pagination title and the title is not 'Blog', but collection exists" do
+        let(:title)     { "Test Title" }
+        let(:page_meta) { { "pagination" => { "title" => title, "collection" => :collection_name } } }
+        let(:page)      { make_page(page_meta) }
+
+        it "will return the title with the word 'Blog'" do
+          expect(subject.page_pagination_title).to eq("Blog – #{title}")
+        end
+      end
+
+      context "with the pagination title and the title is 'Blog', but collection exists" do
+        let(:page_meta) { { "pagination" => { "title" => "Blog", "collection" => :collection_name } } }
+        let(:page)      { make_page(page_meta) }
+
+        it "will return the title with the word 'Blog'" do
+          expect(subject.page_pagination_title).to eq("Blog")
+        end
+      end
+
+      context "with the pagination title and the title is 'Blog', and collection does not exists" do
+        let(:page_meta) { { "pagination" => { "title" => "Blog" } } }
+        let(:page)      { make_page(page_meta) }
+
+        it "will return the title with the word 'Blog'" do
+          expect(subject.page_pagination_title).to eq("Blog")
         end
       end
     end
@@ -102,7 +130,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
         let(:subtitle)        { "Subtitle" }
         let(:page_meta)       { { "title" => title, "subtitle" => subtitle } }
         let(:page)            { make_page(page_meta) }
-        let(:title_separator) { " — " }
+        let(:title_separator) { " – " }
 
         it "will return the two connected by an title_separator" do
           expect(subject.page_subtitle_title).to eql(title + title_separator + subtitle)
@@ -132,14 +160,14 @@ RSpec.describe Jekyll::SeoTag::Drop do
 
     context "title" do
       context "with a page and site title" do
-        context "when site title prioritized" do
+        context "when using a custom site title" do
           it "builds the title" do
-            allow(subject).to receive(:site_title_prioritized?).and_return(true)
-            expect(subject.title).to eql("site title | page title")
+            allow(subject).to receive(:seo_custom_title?).and_return(true)
+            expect(subject.title).to eql("page title | site title")
           end
         end
 
-        context "when page title prioritized" do
+        context "when not using a custom site title" do
           it "builds the title" do
             expect(subject.title).to eql("page title | site title")
           end
@@ -147,18 +175,18 @@ RSpec.describe Jekyll::SeoTag::Drop do
       end
 
       context "with a site description but no page title" do
-        context "when site title prioritized" do
+        context "when using a custom site title" do
           let(:page)  { make_page }
           let(:config) do
-            { "title" => "Site Title", "description" => "site description", "seo_title_prioritization" => "site" }
+            { "title" => "Site Title", "description" => "site description", "seo_custom_title" => true }
           end
 
           it "builds the title" do
-            expect(subject.title).to eql("Site Title")
+            expect(subject.title).to eql("site description | Site Title")
           end
         end
 
-        context "when page title prioritized" do
+        context "when not using a custom site title" do
           let(:page)  { make_page }
           let(:config) do
             { "title" => "site title", "description" => "site description" }
@@ -171,18 +199,18 @@ RSpec.describe Jekyll::SeoTag::Drop do
       end
 
       context "with a site tagline but no page title" do
-        context "when site title prioritized" do
+        context "when using a custom site title" do
           let(:page)  { make_page }
           let(:config) do
-            { "title" => "Site Title", "description" => "site description", "tagline" => "site tagline", "seo_title_prioritization" => "site" }
+            { "title" => "Site Title", "description" => "site description", "tagline" => "site tagline", "seo_custom_title" => true }
           end
 
           it "builds the title" do
-            expect(subject.title).to eql("Site Title")
+            expect(subject.title).to eql("site tagline | Site Title")
           end
         end
 
-        context "when page title prioritized" do
+        context "when not using a custom site title" do
           let(:page)  { make_page }
           let(:config) do
             { "title" => "site title", "description" => "site description", "tagline" => "site tagline" }
@@ -244,29 +272,6 @@ RSpec.describe Jekyll::SeoTag::Drop do
         end
       end
 
-      context "when the page title is Home" do
-        context "when site title prioritized" do
-          let(:page_meta) { { "title" => "Home" } }
-          let(:page)      { make_page(page_meta) }
-          let(:config) do
-            { "title" => "Site Title", "description" => "site description", "tagline" => "site tagline", "seo_title_prioritization" => "site" }
-          end
-
-          it "should return only the site title" do
-            expect(subject.title).to eql("Site Title")
-          end
-        end
-
-        context "when page title prioritized" do
-          let(:page_meta) { { "title" => "Home" } }
-          let(:page)      { make_page(page_meta) }
-
-          it "should return only the site title" do
-            expect(subject.title).to eql("Home | site title")
-          end
-        end
-      end
-
       context "when the page title is nil" do
         let(:page_meta) { { "title" => nil } }
         let(:page)      { make_page(page_meta) }
@@ -280,7 +285,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
     context "determine_detailed_title" do
       context "with a page and site title" do
         it "builds the title" do
-          expect(subject.determine_detailed_title).to eql("site title | page title")
+          expect(subject.determine_detailed_title).to eql("page title | site title")
         end
       end
 
@@ -291,7 +296,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
         end
 
         it "builds the title" do
-          expect(subject.determine_detailed_title).to eql("site title | site description")
+          expect(subject.determine_detailed_title).to eql("site description | site title")
         end
       end
 
@@ -302,7 +307,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
         end
 
         it "builds the title" do
-          expect(subject.determine_detailed_title).to eql("site title | site tagline")
+          expect(subject.determine_detailed_title).to eql("site tagline | site title")
         end
       end
 
@@ -313,7 +318,7 @@ RSpec.describe Jekyll::SeoTag::Drop do
         let(:page) { make_page(page_meta) }
 
         it "builds the title" do
-          expect(subject.determine_detailed_title).to eql("site title | pagination title")
+          expect(subject.determine_detailed_title).to eql("pagination title | site title")
         end
       end
 
@@ -322,10 +327,10 @@ RSpec.describe Jekyll::SeoTag::Drop do
           { "title" => "site title", "subtitle" => "subtitle" }
         end
         let(:page)            { make_page(page_meta) }
-        let(:title_separator) { "—" }
+        let(:title_separator) { "–" }
 
         it "builds the title" do
-          expect(subject.determine_detailed_title).to eql("site title | site title #{title_separator} subtitle")
+          expect(subject.determine_detailed_title).to eql("site title #{title_separator} subtitle | site title")
         end
       end
     end
@@ -686,10 +691,10 @@ RSpec.describe Jekyll::SeoTag::Drop do
     end
 
     it "render default pagination title" do
-      expect(subject.send(:page_number)).to eq(" (page 2 of 10)")
+      expect(subject.send(:page_number)).to eq("Page 2 of 10 for ")
     end
 
-    context "render custom pagination title" do
+    context "render pagination title when passed in" do
       let(:config) { { "seo_paginator_message" => "%<current>s of %<total>s" } }
 
       it "renders the correct page number" do
@@ -697,9 +702,17 @@ RSpec.describe Jekyll::SeoTag::Drop do
       end
     end
 
+    context "render the custom default pagination title" do
+      let(:config) { { "seo_custom_title" => true } }
+
+      it "renders the correct page number" do
+        expect(subject.send(:page_number)).to eq("(page 2 of 10)")
+      end
+    end
+
     context "render built-in pagination title" do
       it "renders the correct page number" do
-        expect(subject.send(:page_number)).to eq(" (page 2 of 10)")
+        expect(subject.send(:page_number)).to eq("Page 2 of 10 for ")
       end
     end
   end

--- a/spec/jekyll_seo_tag/json_ld_drop_spec.rb
+++ b/spec/jekyll_seo_tag/json_ld_drop_spec.rb
@@ -201,15 +201,16 @@ RSpec.describe Jekyll::SeoTag::JSONLDDrop do
 
   context "sorting the final json value" do
     it "accurately sorts the final json value based on the sort precedence set" do
-      any_char = %r{[\/a-zA-Z\d\s:-]+}
-      match_one = %r{"headline":"#{any_char}","name":"#{any_char}","url":"}
-      match_two = %r{"dateModified":"#{any_char}","datePublished":"#{any_char}","author":}
-      match_three = %r{"description":"#{any_char}","sameAs":}
-      match_four = %r{"image":"#{any_char}","@type":"#{any_char}","@context":"#{any_char}"}
+      any_char = %r![/a-zA-Z\d\s:-]+!
+      match_one = %r!"headline":"#{any_char}","name":"#{any_char}","url":"!
+      match_two = %r!"dateModified":"#{any_char}","datePublished":"#{any_char}","author":!
+      match_three = %r!"description":"#{any_char}","sameAs":!
+      match_four = %r!"image":"#{any_char}","@type":"#{any_char}","@context":"#{any_char}"!
       expect(subject.to_json).to start_with('{"headline')
       expect(subject.to_json).to match(match_one)
       expect(subject.to_json).to match(match_two)
       expect(subject.to_json).to match(match_three)
+      expect(subject.to_json).not_to match(match_four)
       expect(subject.to_json).to end_with('"@type":"BlogPosting","@context":"https://schema.org"}')
     end
   end

--- a/spec/jekyll_seo_tag_integration_spec.rb
+++ b/spec/jekyll_seo_tag_integration_spec.rb
@@ -50,15 +50,15 @@ RSpec.describe Jekyll::SeoTag do
     end
 
     context "with site.name" do
-      context "when site title prioritized" do
-        let(:site) { make_site("name" => "Site Title", "seo_title_prioritization" => "site") }
+      context "when using a custom site title" do
+        let(:site) { make_site("name" => "Site Title", "seo_custom_title" => true) }
 
         it "builds the title with a page title and site name" do
-          expect(output).to match(%r!<title>Site Title \| foo</title>!)
+          expect(output).to match(%r!<title>foo \| Site Title</title>!)
         end
       end
 
-      context "when page title prioritized" do
+      context "when not using a custom site title" do
         let(:site) { make_site("name" => "Site Name") }
 
         it "builds the title with a page title and site name" do
@@ -68,15 +68,15 @@ RSpec.describe Jekyll::SeoTag do
     end
 
     context "with site.title" do
-      context "when site title prioritized" do
-        let(:site) { make_site("title" => "Site Title", "seo_title_prioritization" => "site" ) }
+      context "when using a custom site title" do
+        let(:site) { make_site("title" => "Site Title", "seo_custom_title" => true) }
 
         it "builds the title with a page title and site title" do
-          expect(output).to match(%r!<title>Site Title \| foo</title>!)
+          expect(output).to match(%r!<title>foo \| Site Title</title>!)
         end
       end
 
-      context "when page title prioritized" do
+      context "when not using a custom site title" do
         let(:site) { make_site("title" => "bar") }
 
         it "builds the title with a page title and site title" do
@@ -94,15 +94,15 @@ RSpec.describe Jekyll::SeoTag do
     end
 
     context "with site.title and site.description" do
-      context "when site title prioritized" do
-        let(:site) { make_site("title" => "Site Title", "description" => "Site Description", "seo_title_prioritization" => "site") }
+      context "when using a custom site title" do
+        let(:site) { make_site("title" => "Site Title", "description" => "Site Description", "seo_custom_title" => true) }
 
         it "builds the title with a page title and site title" do
-          expect(output).to match(%r!<title>Site Title \| foo</title>!)
+          expect(output).to match(%r!<title>foo \| Site Title</title>!)
         end
       end
 
-      context "when page title prioritized" do
+      context "when not using a custom site title" do
         let(:site) { make_site("title" => "foo", "description" => "Site Description") }
 
         it "builds the title with a page title and site description" do
@@ -129,33 +129,33 @@ RSpec.describe Jekyll::SeoTag do
   end
 
   context "with site.title and page.pagination.title" do
-    context "when site title prioritized" do
-      let(:site) { make_site("title" => "Site Title", "seo_title_prioritization" => "site") }
+    context "when using a custom site title" do
+      let(:site) { make_site("title" => "Site Title", "seo_custom_title" => true) }
       let(:page_meta) do
         { "title" => "site title", "pagination" => { "title" => "pagination title" } }
       end
       let(:page) { make_page(page_meta) }
 
       it "should build the title" do
-        expect(output).to match(%r!<title>Site Title | pagination title</title>!)
+        expect(output).to match(%r!<title>pagination title \| Site Title</title>!)
       end
     end
   end
 
   context "with site.title, page.title, and page.subtitle" do
-    context "when site title prioritized" do
-      let(:site)      { make_site("title" => "Site Title", "seo_title_prioritization" => "site") }
+    context "when using a custom site title" do
+      let(:site)      { make_site("title" => "Site Title", "seo_custom_title" => true) }
       let(:title)     { "Test Title" }
       let(:subtitle)  { "Subtitle" }
       let(:page_meta) { { "title" => title, "subtitle" => subtitle } }
       let(:page)      { make_page(page_meta) }
 
       it "should build the title" do
-        expect(output).to match(%r!<title>Site Title | title — subtitle</title>!)
+        expect(output).to match(%r!<title>title – subtitle | Site Title</title>!)
       end
     end
 
-    context "when page title prioritized" do
+    context "when not using a custom site title" do
       let(:site)      { make_site("title" => "Site Title") }
       let(:title)     { "Test Title" }
       let(:subtitle)  { "Subtitle" }
@@ -168,27 +168,16 @@ RSpec.describe Jekyll::SeoTag do
     end
   end
 
-  context "with site.title and page.title == Home and https://emmasax.com" do
-    let(:site)      { make_site("title" => "Site Title", "seo_title_prioritization" => "site") }
-    let(:title)     { "Home" }
-    let(:page_meta) { { "title" => title } }
-    let(:page)      { make_page(page_meta) }
-
-    it "should build the title" do
-      expect(output).to match(%r!<title>Site Title</title>!)
-    end
-  end
-
   context "with site.title and site.description" do
-    context "when site title prioritized" do
-      let(:site) { make_site("title" => "Site Title", "description" => "Site Description", "seo_title_prioritization" => "site") }
+    context "when using a custom site title" do
+      let(:site) { make_site("title" => "Site Title", "description" => "Site Description", "seo_custom_title" => true) }
 
       it "builds the title with site title and description" do
-        expect(output).to match(%r!<title>Site Title</title>!)
+        expect(output).to match(%r!<title>Site Description | Site Title</title>!)
       end
     end
 
-    context "when page title prioritized" do
+    context "when not using a custom site title" do
       let(:site) { make_site("title" => "Site Title", "description" => "Site Description") }
 
       it "builds the title with site title and description" do


### PR DESCRIPTION
When using a custom title (passed in via the new flag `seo_custom_title: true` in the `_config.yml`), then have the `title` meta of the HTML pages of the form `Page Title | Site Title`. If using pagination, still put pagination at the end of the page title (`Page Title (page 4 of 5) | Site Title`).

When not using the `seo_custom_title` flag or when it's set to `false`, then use the generic default page titles and pagination form.

This pull request also does a lot of work to address Rubocop conerns that _for some reason_ have not been an issue up until now.